### PR TITLE
Fix typo in welcome text

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -17,7 +17,7 @@ export default function Index() {
         <WelcomeText>
           Vous entrez dans une aventure unique et ferez progresser votre héro au
           fil des écrans de cette histoire. Attention aux adversaires et autres
-          montres que vous rencontrerez !
+          monstres que vous rencontrerez !
         </WelcomeText>
       </AboveNavWrapper>
       <NavWrapper>


### PR DESCRIPTION
## Summary
- correct typo in the French welcome text

## Testing
- `npm run test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cee8fb8483288cc5b008288d050a