### PR TITLE
Update dice tests and fix roll formula

### DIFF
--- a/src/core/actions/__tests__/d6-test.ts
+++ b/src/core/actions/__tests__/d6-test.ts
@@ -2,11 +2,12 @@ import { D6 } from '@actions'
 
 describe('Given a D6', () => {
   it('When launched it has a result between 1 and 6', () => {
-    const dice = D6(1, () => 1)
-    expect(dice).toBe(6)
+    expect(D6(1, () => 0)).toBe(1)
+    expect(D6(1, () => 0.9999)).toBe(6)
   })
+
   it('When launched D6x2 it has a result between 2 and 12', () => {
-    const dice = D6(2, () => 1)
-    expect(dice).toBe(12)
+    expect(D6(2, () => 0)).toBe(2)
+    expect(D6(2, () => 0.9999)).toBe(12)
   })
 })

--- a/src/core/types/__tests__/dice-test.ts
+++ b/src/core/types/__tests__/dice-test.ts
@@ -3,20 +3,20 @@ import { Dice } from '../dice'
 describe('Dice', () => {
   it('Should roll a 12 for one roll of a 12 side dice', () => {
     const dice = new Dice(12)
-    dice.randomizer = () => 1
+    dice.randomizer = () => 0.9999
 
     expect(dice.roll()).toBe(12)
   })
   it('Should roll a 6 for one roll', () => {
     const dice = new Dice()
-    dice.randomizer = () => 1
+    dice.randomizer = () => 0.9999
 
     expect(dice.roll()).toBe(6)
   })
 
   it('Should roll a 18 for 3 rolls', () => {
     const dice = new Dice()
-    dice.randomizer = () => 1
+    dice.randomizer = () => 0.9999
 
     expect(dice.roll(3)).toBe(18)
   })

--- a/src/core/types/dice.ts
+++ b/src/core/types/dice.ts
@@ -8,7 +8,7 @@ export class Dice {
 
   roll(rolls: number = 1) {
     return Array<number>(rolls)
-      .fill(1 + Math.floor(this.randomizer() * (this.side - 1)))
+      .fill(1 + Math.floor(this.randomizer() * this.side))
       .reduce((previousValue, currentValue) => previousValue + currentValue, 0)
   }
 }


### PR DESCRIPTION
## Summary
- fix roll formula in Dice to account for full range of sides
- update dice tests to use 0/0.9999 randomizers
- verify D6 boundaries using custom randomizers

## Testing
- `yarn test src/core/actions/__tests__/d6-test.ts --watchAll=false` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873cf01e73c832892d481d700dcf3b0