### PR TITLE
Refactor useReadScene hook

### DIFF
--- a/src/core/hooks/__tests__/useReadScene-test.tsx
+++ b/src/core/hooks/__tests__/useReadScene-test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { WrapperTestExt } from '@helpers/WrapperTestExt'
+import { act, renderHook } from '@testing-library/react-native'
+import { GameState } from '@types'
+import { GAME_STORE } from '../useGameStore'
+import { useReadScene } from '../useReadScene'
+
+const makeWrapper =
+  (runOnStart?: (store: GameState) => void) =>
+  // eslint-disable-next-line react/display-name
+  ({ children }: { children: React.ReactNode }) => (
+    <WrapperTestExt runOnStart={runOnStart}>{children}</WrapperTestExt>
+  )
+
+describe('useReadScene', () => {
+  it('flags scene as empty before starting the book', () => {
+    const { result } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(),
+    })
+    expect(result.current.sceneIsEmpty).toBe(true)
+    expect(result.current.sceneIsNormal).toBe(true)
+  })
+
+  it('computes flags for a normal scene', () => {
+    const runOnStart = (store: GameState) => {
+      store.startBook()
+    }
+    const { result } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(runOnStart),
+    })
+    expect(result.current.sceneIsEmpty).toBe(false)
+    expect(result.current.sceneNeedFight).toBe(false)
+    expect(result.current.sceneIsNormal).toBe(true)
+  })
+
+  it('detects fight scenes', () => {
+    const runOnStart = (store: GameState) => {
+      store.startBook()
+      store.moveToScene('1-3')
+    }
+    const { result } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(runOnStart),
+    })
+    expect(result.current.sceneNeedFight).toBe(true)
+    expect(result.current.fightText).toMatch(/Vous devez battre Toto/)
+  })
+
+  it('detects success and failure scenes', () => {
+    const startSuccess = (store: GameState) => {
+      store.startBook()
+      store.moveToScene('1-1')
+      store.moveToScene('2-1')
+      store.moveToScene('3-1')
+    }
+    const { result: success } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(startSuccess),
+    })
+    expect(success.current.sceneIsSuccess).toBe(true)
+
+    const startFailure = (store: GameState) => {
+      store.startBook()
+      store.moveToScene('1-2')
+    }
+    const { result: failure } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(startFailure),
+    })
+    expect(failure.current.sceneIsFailure).toBe(true)
+  })
+
+  it('calls store actions through callbacks', () => {
+    const runOnStart = (store: GameState) => {
+      store.startBook()
+      store.consumeItemByOne = jest.fn()
+      store.resetEndurance = jest.fn()
+      store.moveToScene = jest.fn()
+      store.quitGame = jest.fn()
+    }
+    const { result } = renderHook(() => useReadScene(), {
+      wrapper: makeWrapper(runOnStart),
+    })
+
+    act(() => {
+      result.current.actionItem(result.current.items[0])
+    })
+    expect(GAME_STORE.getState().resetEndurance).toHaveBeenCalled()
+    expect(GAME_STORE.getState().consumeItemByOne).toHaveBeenCalled()
+
+    act(() => {
+      result.current.moveToScene('1-1')
+      result.current.quitGame()
+    })
+    expect(GAME_STORE.getState().moveToScene).toHaveBeenCalledWith('1-1')
+    expect(GAME_STORE.getState().quitGame).toHaveBeenCalled()
+  })
+})

--- a/src/core/hooks/useReadScene.tsx
+++ b/src/core/hooks/useReadScene.tsx
@@ -1,27 +1,48 @@
 import { ItemProps } from '@types'
-import { useGameStore } from './useGameStore'
+import { GAME_STORE, useGameStore } from './useGameStore'
+import { useCallback, useMemo } from 'react'
 
 export const useReadScene = () => {
-  const store = useGameStore((state) => state)
-  const { character, currentScene, moveToScene, quitGame } = store
+  const currentScene = useGameStore((state) => state.currentScene)
+  const items = useGameStore((state) => state.character.items)
+  const moveToScene = useGameStore((state) => state.moveToScene)
+  const quitGame = useGameStore((state) => state.quitGame)
+
+  const sceneIsEmpty = useMemo(() => currentScene.id === '', [currentScene.id])
+  const sceneNeedFight = useMemo(
+    () =>
+      !!currentScene.opponent && currentScene.opponent.abilities.endurance > 0,
+    [currentScene.opponent?.abilities.endurance],
+  )
+  const sceneIsSuccess = useMemo(
+    () => currentScene.isEnding && currentScene.endingType === 'success',
+    [currentScene.isEnding, currentScene.endingType],
+  )
+  const sceneIsFailure = useMemo(
+    () => currentScene.isEnding && currentScene.endingType === 'failure',
+    [currentScene.isEnding, currentScene.endingType],
+  )
+  const sceneIsNormal = useMemo(
+    () => !currentScene.isEnding,
+    [currentScene.isEnding],
+  )
+
+  const actionItem = useCallback((item: ItemProps) => {
+    item.action(GAME_STORE.getState())
+  }, [])
 
   return {
-    sceneIsEmpty: currentScene.id === '',
-    sceneNeedFight:
-      !!currentScene.opponent && currentScene.opponent.abilities.endurance > 0,
-    sceneIsSuccess:
-      currentScene.isEnding && currentScene.endingType === 'success',
-    sceneIsFailure:
-      currentScene.isEnding && currentScene.endingType === 'failure',
-    sceneIsNormal: !currentScene.isEnding,
-    items: character.items,
+    sceneIsEmpty,
+    sceneNeedFight,
+    sceneIsSuccess,
+    sceneIsFailure,
+    sceneIsNormal,
+    items,
     text: currentScene.text,
     fightText:
       (!!currentScene.opponent && currentScene.opponent.description) || '',
     actions: currentScene.actions,
-    actionItem: (item: ItemProps) => {
-      item.action(store)
-    },
+    actionItem,
     moveToScene,
     quitGame,
   }


### PR DESCRIPTION
## Summary
- refactor `useReadScene` to use store selectors and memoization
- add a dedicated test suite for `useReadScene`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873d3b55ad0832899eab7f4b9f6d675