### PR TITLE
Update hooks for book meta service

### DIFF
--- a/src/core/hooks/__tests__/useChooseSimpleStory-test.tsx
+++ b/src/core/hooks/__tests__/useChooseSimpleStory-test.tsx
@@ -1,21 +1,33 @@
 import { TEST_BOOK } from '@helpers/TEST_BOOK'
-import { renderHook } from '@testing-library/react-native'
+import { renderHook, waitFor } from '@testing-library/react-native'
 import { act } from 'react'
 import { useChooseSimpleStory } from '../useChooseSimpleStory'
 import { GAME_STORE } from '../useGameStore'
+import { bookService } from '@services/bookService'
+
+jest.mock('@services/bookService', () => ({
+  bookService: {
+    getBookMetaList: jest.fn().mockResolvedValue([
+      { name: TEST_BOOK.title, text: TEST_BOOK.description, reference: 0 },
+    ]),
+  },
+}))
 
 describe('useChooseSimpleStory', () => {
-  it('returns the correct title and description', () => {
+  it('returns the correct title and description', async () => {
     const { result } = renderHook(() => useChooseSimpleStory())
-    const { title, description, getSelectedBook } = result.current
-    expect(title).toBe(TEST_BOOK.title)
-    expect(description).toBe(TEST_BOOK.description)
-    expect(getSelectedBook()).toEqual(TEST_BOOK)
+
+    await waitFor(() => {
+      expect(result.current.title).toBe(TEST_BOOK.title)
+      expect(result.current.description).toBe(TEST_BOOK.description)
+    })
+    expect(result.current.getSelectedBook()).toEqual(TEST_BOOK)
   })
+
   it('calls setBook with the correct book', () => {
     const { result } = renderHook(() => useChooseSimpleStory())
     const { setBook } = result.current
-    act(() => setBook(TEST_BOOK))
-    expect(GAME_STORE.getState().gameBook).toEqual(TEST_BOOK)
+    act(() => setBook({ id: 1, intro: 'intro' }))
+    expect(GAME_STORE.getState().gameBook).toEqual({ id: 1, intro: 'intro' })
   })
 })

--- a/src/core/hooks/__tests__/useGetStoriesToChoose-test.tsx
+++ b/src/core/hooks/__tests__/useGetStoriesToChoose-test.tsx
@@ -1,12 +1,27 @@
-import { getBooks } from '@api'
 import { TEST_BOOK } from '@helpers/TEST_BOOK'
 import { WrapperTest } from '@helpers/WrapperTest'
 import { act, renderHook, waitFor } from '@testing-library/react-native'
 import { useGetStoriesToChoose } from '../useGetStoriesToChoose'
+import { ShortStory } from '@types'
+
+const shortList: ShortStory[] = [
+  {
+    name: 'Les mésaventures de Grok, gobelin maladroit',
+    text: 'Un jeune gobelin voleur tente désespérément de rejoindre son père perdu dans la forêt sauvage.',
+    reference: 0,
+  },
+  {
+    name: TEST_BOOK.title,
+    text: TEST_BOOK.description,
+    reference: 1,
+  },
+]
+
+const getShortBooks = async () => shortList
 
 describe('useGetStoriesToChoose', () => {
   it('should start with loading state', async () => {
-    const { result } = renderHook(() => useGetStoriesToChoose(getBooks), {
+    const { result } = renderHook(() => useGetStoriesToChoose(getShortBooks), {
       wrapper: WrapperTest,
     })
 
@@ -20,7 +35,7 @@ describe('useGetStoriesToChoose', () => {
   })
 
   it('should handle loading state correctly', async () => {
-    const { result } = renderHook(() => useGetStoriesToChoose(getBooks), {
+    const { result } = renderHook(() => useGetStoriesToChoose(getShortBooks), {
       wrapper: WrapperTest,
     })
     await act(async () => {
@@ -31,29 +46,18 @@ describe('useGetStoriesToChoose', () => {
     })
   })
   it('should format books data correctly', async () => {
-    const { result } = renderHook(() => useGetStoriesToChoose(getBooks), {
+    const { result } = renderHook(() => useGetStoriesToChoose(getShortBooks), {
       wrapper: WrapperTest,
     })
     await act(async () => {
       result.current.load()
     })
     await waitFor(() => {
-      expect(result.current.books).toEqual([
-        {
-          name: 'Les mésaventures de Grok, gobelin maladroit',
-          text: 'Un jeune gobelin voleur tente désespérément de rejoindre son père perdu dans la forêt sauvage.',
-          reference: 0,
-        },
-        {
-          name: 'Fugiat ipsum sunt cupidatat cillum duis eiusmod adipisicing excepteur quis',
-          text: 'Fugiat ipsum sunt cupidatat cillum duis eiusmod adipisicing excepteur quis Lorem proident ut eu labore.',
-          reference: 1,
-        },
-      ])
+      expect(result.current.books).toEqual(shortList)
     })
   })
   it('should handle empty books array', async () => {
-    const { result } = renderHook(() => useGetStoriesToChoose(getBooks), {
+    const { result } = renderHook(() => useGetStoriesToChoose(getShortBooks), {
       wrapper: WrapperTest,
     })
     await waitFor(() => {
@@ -62,7 +66,7 @@ describe('useGetStoriesToChoose', () => {
     })
   })
   it('Should set the book selected by a key', async () => {
-    const { result } = renderHook(() => useGetStoriesToChoose(getBooks), {
+    const { result } = renderHook(() => useGetStoriesToChoose(getShortBooks), {
       wrapper: WrapperTest,
     })
     await act(async () => {
@@ -72,7 +76,7 @@ describe('useGetStoriesToChoose', () => {
       expect(result.current.loading).toBe(false)
     })
     const b = await result.current.selectBook(1)
-    expect(b).toStrictEqual(TEST_BOOK)
+    expect(b).toStrictEqual(shortList[1])
   })
   it('Should raise an error if book getter is wrong', async () => {
     const { result } = renderHook(

--- a/src/core/hooks/__tests__/useReadIntroduction-test.tsx
+++ b/src/core/hooks/__tests__/useReadIntroduction-test.tsx
@@ -25,13 +25,11 @@ describe('useReadIntroduction', () => {
     expect(result.current).toHaveProperty('startBook')
     expect(typeof result.current.startBook).toBe('function')
   })
-  it('should call startBook function', () => {
-    GAME_STORE.getState().startBook = jest.fn()
+  it('should start the book and load first scene', () => {
     const { result } = renderHook(() => useReadIntroduction(), {
       wrapper: WrapperTestExt,
     })
-    expect(result.current.startBook).toBeDefined()
     result.current.startBook()
-    expect(GAME_STORE.getState().startBook).toHaveBeenCalledTimes(1)
+    expect(GAME_STORE.getState().currentScene.id).toBe('1')
   })
 })

--- a/src/core/hooks/useChooseSimpleStory.tsx
+++ b/src/core/hooks/useChooseSimpleStory.tsx
@@ -1,15 +1,32 @@
 import { TEST_BOOK } from '@helpers/TEST_BOOK'
+import { ShortStory } from '@types'
+import { bookService } from '@services/bookService'
 import { useGameStore } from './useGameStore'
+import { useEffect, useState } from 'react'
 
 export const useChooseSimpleStory = () => {
-  const setBook = useGameStore((state) => state.setBook)
+  const [meta, setMeta] = useState<ShortStory | null>(null)
+  const storeSetBook = useGameStore((state) => state.setBook)
 
-  const getSelectedBook = () => {
-    return TEST_BOOK
+  useEffect(() => {
+    bookService
+      .getBookMetaList()
+      .then((list) => {
+        if (list.length > 0) setMeta(list[0])
+      })
+      .catch(() => {})
+    // we ignore the error here on purpose
+  }, [])
+
+  const getSelectedBook = () => TEST_BOOK
+
+  const setBook = ({ id, intro }: { id: string | number; intro: string }) => {
+    // store only minimal information as requested
+    storeSetBook({ id, intro } as any)
   }
 
-  const title = getSelectedBook().title
-  const description = getSelectedBook().description
+  const title = meta?.name ?? getSelectedBook().title
+  const description = meta?.text ?? getSelectedBook().description
 
   return { title, description, getSelectedBook, setBook }
 }

--- a/src/core/hooks/useGetStoriesToChoose.tsx
+++ b/src/core/hooks/useGetStoriesToChoose.tsx
@@ -1,11 +1,11 @@
-import { BookProps, ShortListOfStories } from '@types'
+import { ShortListOfStories, ShortStory } from '@types'
 import { useState } from 'react'
 
 /**
  * Get the stories available and build a list of them so the user can make a choice
  */
 export const useGetStoriesToChoose = (
-  bookGetter: () => Promise<BookProps[]>,
+  bookGetter: () => Promise<ShortStory[]>,
 ) => {
   const [books, setBooks] = useState<ShortListOfStories>([])
   const [error, setError] = useState<Error | null>(null)
@@ -13,7 +13,7 @@ export const useGetStoriesToChoose = (
 
   const selectBook = async (
     key: number | string,
-  ): Promise<BookProps | undefined> => {
+  ): Promise<ShortStory | undefined> => {
     const booksRead = await bookGetter()
     return booksRead?.at(Number(key))
   }
@@ -23,13 +23,7 @@ export const useGetStoriesToChoose = (
       setLoading(true)
       const booksRead = await bookGetter()
       if (booksRead) {
-        setBooks(
-          booksRead.map((book, index) => ({
-            name: book.title,
-            text: book.description,
-            reference: index,
-          })),
-        )
+        setBooks(booksRead)
       }
       setLoading(false)
     } catch (e) {

--- a/src/core/hooks/useReadIntroduction.tsx
+++ b/src/core/hooks/useReadIntroduction.tsx
@@ -8,12 +8,16 @@ import { useGameStore } from './useGameStore'
  * It also provides a function to start the book.
  */
 export const useReadIntroduction = () => {
-  const introduction = useGameStore((state) => state.gameBook.introduction)
-  const startBook = useGameStore((state) => state.startBook)
+  const bookIntro = useGameStore((state) => state.gameBook.introduction)
+  const startBookFromStore = useGameStore((state) => state.startBook)
+
+  const startBook = () => {
+    startBookFromStore()
+  }
 
   return {
-    title: introduction?.title ?? 'Error',
-    introduction: introduction?.text ?? 'Error',
+    title: bookIntro?.title ?? 'Error',
+    introduction: bookIntro?.text ?? 'Error',
     startBook,
   }
 }

--- a/src/shared/services/bookService.ts
+++ b/src/shared/services/bookService.ts
@@ -1,0 +1,13 @@
+import { getBooks } from '@api'
+import { ShortStory } from '@types'
+
+export const bookService = {
+  async getBookMetaList(): Promise<ShortStory[]> {
+    const books = await getBooks()
+    return books.map((b, index) => ({
+      name: b.title,
+      text: b.description,
+      reference: index,
+    }))
+  },
+}


### PR DESCRIPTION
## Summary
- add a simple `bookService` to fetch book metadata
- fetch metadata in `useChooseSimpleStory`
- adapt `useReadIntroduction` to read `bookIntro`
- update `useGetStoriesToChoose` to consume a short book list
- adjust related unit tests

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873d24b64388328a5761eb0cca02e97