### PR TITLE
Add bookService API

### DIFF
--- a/src/core/api/bookService.ts
+++ b/src/core/api/bookService.ts
@@ -1,0 +1,43 @@
+import path from 'path'
+import { promises as fs } from 'fs'
+import type { ShortStory, BookIntroductionProps, SceneProps, BookProps } from '.../types'
+
+const BOOKS_DIR = path.join(__dirname, '../../../assets/books')
+
+const loadBook = async (id: string): Promise<BookProps> => {
+  const mod = await import(`../../../assets/books/${id}.json`)
+  return mod.default as BookProps
+}
+
+const listBookIds = async (): Promise<string[]> => {
+  const files = await fs.readdir(BOOKS_DIR)
+  return files
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+}
+
+export const getBookMetaList = async (): Promise<ShortStory[]> => {
+  const ids = await listBookIds()
+  const books = await Promise.all(ids.map((id) => loadBook(id)))
+
+  return books.map((b, index) => ({
+    name: b.title,
+    text: b.description,
+    reference: ids[index],
+  }))
+}
+
+export const getBookIntro = async (
+  id: string,
+): Promise<BookIntroductionProps> => {
+  const book = await loadBook(id)
+  return book.introduction
+}
+
+export const getScene = async (
+  id: string,
+  sceneId: string,
+): Promise<SceneProps> => {
+  const book = await loadBook(id)
+  return book.scenes[sceneId]
+}

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,3 +1,4 @@
+export { getBookMetaList, getBookIntro, getScene } from "./bookService"
 export { createResource } from './createResource'
 export { getBooks } from './getBooks'
 export { getStory } from './getStory'


### PR DESCRIPTION
## Summary
- implement `bookService` with helpers to load book data from JSON files
- re-export the new helpers from the API entrypoint

## Testing
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873d248a7f48328919754267f32a6d5