### PR TITLE
Fix lint warnings

### DIFF
--- a/src/core/actions/__tests__/build-scene-test.ts
+++ b/src/core/actions/__tests__/build-scene-test.ts
@@ -5,7 +5,7 @@ import { BuildScene } from '../build-scene'
 describe('BuildScene', () => {
   it('Build empty scenes', () => {
     try {
-      const scenes = BuildScene('0', EmptyScenes)
+      BuildScene('0', EmptyScenes)
     } catch (e) {
       expect(e).toBeDefined()
     }

--- a/src/core/api/bookService.ts
+++ b/src/core/api/bookService.ts
@@ -1,6 +1,11 @@
 import path from 'path'
 import { promises as fs } from 'fs'
-import type { ShortStory, BookIntroductionProps, SceneProps, BookProps } from '.../types'
+import type {
+  ShortStory,
+  BookIntroductionProps,
+  SceneProps,
+  BookProps,
+} from '../types'
 
 const BOOKS_DIR = path.join(__dirname, '../../../assets/books')
 

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -1,4 +1,4 @@
-export { getBookMetaList, getBookIntro, getScene } from "./bookService"
+export { getBookMetaList, getBookIntro, getScene } from './bookService'
 export { createResource } from './createResource'
 export { getBooks } from './getBooks'
 export { getStory } from './getStory'

--- a/src/core/hooks/__tests__/useChooseSimpleStory-test.tsx
+++ b/src/core/hooks/__tests__/useChooseSimpleStory-test.tsx
@@ -3,10 +3,9 @@ import { renderHook, waitFor } from '@testing-library/react-native'
 import { act } from 'react'
 import { useChooseSimpleStory } from '../useChooseSimpleStory'
 import { GAME_STORE } from '../useGameStore'
-import { bookService } from '../../../shared/services/bookService'
 
 jest.mock('../../../shared/services/bookService', () => {
-  const { TEST_BOOK } = require('@helpers/TEST_BOOK')
+  const { TEST_BOOK } = jest.requireActual('@helpers/TEST_BOOK')
   return {
     bookService: {
       getBookMetaList: jest

--- a/src/core/hooks/__tests__/useFight-test.tsx
+++ b/src/core/hooks/__tests__/useFight-test.tsx
@@ -103,7 +103,7 @@ describe('useFight', () => {
     act(() => {
       result.current.onChanceSuccess()
     })
-    expect(mockFightInstance.doSuccessChance).toHaveBeenCalled()
+    expect(mockServiceInstance.applyChanceSuccess).toHaveBeenCalled()
     expect(result.current.opponentEndurance).toBe(8)
     expect(result.current.heroEndurance).toBe(18)
   })
@@ -113,7 +113,7 @@ describe('useFight', () => {
     act(() => {
       result.current.onChanceFailure()
     })
-    expect(mockFightInstance.doFailChance).toHaveBeenCalled()
+    expect(mockServiceInstance.applyChanceFailure).toHaveBeenCalled()
     expect(result.current.opponentEndurance).toBe(8)
     expect(result.current.heroEndurance).toBe(18)
   })

--- a/src/core/hooks/__tests__/useGetStoriesToChoose-test.tsx
+++ b/src/core/hooks/__tests__/useGetStoriesToChoose-test.tsx
@@ -19,9 +19,6 @@ const shortList: ShortStory[] = [
     reference: 1,
   },
 ]
-
-const getShortBooks = async () => shortList
-
 describe('useGetStoriesToChoose', () => {
   it('should start with loading state', async () => {
     const { result } = renderHook(() => useGetStoriesToChoose(listBooks), {

--- a/src/core/hooks/useFight.tsx
+++ b/src/core/hooks/useFight.tsx
@@ -1,8 +1,6 @@
 import { BuildAttacker } from '@actions'
 import { AttackerProps } from '@types'
 import { useEffect, useRef, useState } from 'react'
-import { useFightChance } from './useFightChance'
-import { useFightRound } from './useFightRound'
 import { useGameStore } from './useGameStore'
 import { FightService } from '../services/FightService'
 

--- a/src/core/hooks/useReadScene.tsx
+++ b/src/core/hooks/useReadScene.tsx
@@ -12,7 +12,7 @@ export const useReadScene = () => {
   const sceneNeedFight = useMemo(
     () =>
       !!currentScene.opponent && currentScene.opponent.abilities.endurance > 0,
-    [currentScene.opponent?.abilities.endurance],
+    [currentScene.opponent],
   )
   const sceneIsSuccess = useMemo(
     () => currentScene.isEnding && currentScene.endingType === 'success',

--- a/src/core/stores/__tests__/game-test.tsx
+++ b/src/core/stores/__tests__/game-test.tsx
@@ -32,7 +32,9 @@ describe('Game (store)', () => {
     const { result } = renderHook(() =>
       useStore(store, (state) => state.setBook),
     )
-    act(() => result.current({ id: 'TEST_BOOK', intro: TEST_BOOK.introduction }))
+    act(() =>
+      result.current({ id: 'TEST_BOOK', intro: TEST_BOOK.introduction }),
+    )
 
     expect(store.getState()).toHaveProperty('bookId', 'TEST_BOOK')
     expect(store.getState().bookIntro).not.toBe(EmptyBookIntroduction)

--- a/src/core/stores/game.ts
+++ b/src/core/stores/game.ts
@@ -1,5 +1,5 @@
 import { BuildBackpack } from '@actions'
-import { bookService } from '@services/book'
+import { bookService } from '../../shared/services/book'
 import {
   BookIntroductionProps,
   CharacterRawProps,
@@ -7,8 +7,6 @@ import {
   EmptyBookIntroduction,
   EmptyCharacter,
   EmptyScene,
-  EmptyBookIntroduction,
-  EmptyScenes,
   GameProps,
   GameState,
 } from '@types'

--- a/src/core/types/game.ts
+++ b/src/core/types/game.ts
@@ -1,7 +1,6 @@
 import { BookIntroductionProps, EmptyBookIntroduction } from './introduction'
 import { CharacterProps, CharacterRawProps, EmptyCharacter } from './character'
 import { EmptyScene, Scene } from './scene'
-import { EmptyScenes, ScenesProps } from './scenes'
 
 export interface GameProps {
   /**

--- a/src/screens/choose-story/__tests__/ChooseStory-test.tsx
+++ b/src/screens/choose-story/__tests__/ChooseStory-test.tsx
@@ -3,8 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react-native'
 import ChooseStory from '../choose-story'
 
 // Mocks
-const mockSetBook = jest.fn()
-const mockSelectBook = jest.fn()
 const mockRoute = jest.fn()
 // jest.mock('@core', () => ({
 //   ...jest.requireActual('@core'),


### PR DESCRIPTION
## Summary
- fix unused variable in BuildScene test
- reformat imports in book service
- update quoting style for API index exports
- rely on `jest.requireActual` in ChooseSimpleStory test
- clean up GetStoriesToChoose test formatting
- remove unused imports in useFight hook
- fix memo dependency in useReadScene
- adjust Game store book setter formatting
- fix service path and remove unused imports
- drop unused scene imports in game types
- clean up ChooseStory test mocks
- fix fight hook test referencing the service mock

## Testing
- `npx eslint "src/**/*.{ts,tsx}"`
- `npm test --silent` *(fails: useFight, useReadScene, useGetStoriesToChoose, ChooseStory)*

------
https://chatgpt.com/codex/tasks/task_e_68750acb7a048328a6bc3eeaeab4c123