### PR TITLE
chore: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to automatically propose dependency updates for `package.json` and `yarn.lock`

## Testing
- `npm run test:final` *(fails: Cannot find module './useGoToCreateUser')*

------
https://chatgpt.com/codex/tasks/task_e_6873fbe90ee083288ef8ff7cb222e23a